### PR TITLE
Add a generic top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Data Logger for HEPA filter testing
+This repository contains firmware, test code, and instructions associated with the data logger used for HEPA filter testing and general air quality monitoring. 
+
+The [wiki](https://github.com/airpartners/logger/wiki) contains a comprehensive guide to provisioning, deploying, and running the sensor box, the [test](https://github.com/airpartners/logger/tree/master/test) folder contains test code, and the repo's [top-level directory](https://github.com/airpartners/logger) includes firmware and scripts needed to run the box in production.
+
+As of Fall 2020, we've been using the [GitHub Issues](https://github.com/airpartners/logger/issues) to track bugs and tasks and the [Hardware Overview](https://github.com/airpartners/logger/wiki/hardware-overview) section of the wiki to track the current state of hardware the team is working on.


### PR DESCRIPTION
Add a generic top-level README to help facilitate onboarding and quick navigation of the repo and wiki. This work is also associated with this [GitHub issue](https://github.com/airpartners/logger/issues/9).