### PR TITLE
Added timing parameter to MCPC class code.

### DIFF
--- a/serialdevices.py
+++ b/serialdevices.py
@@ -121,6 +121,15 @@ class MCPC(SerialDevice):
     Interface to a Brechtel Mixing Condensation Particle Counter device.
     Documentation at https://github.com/airpartners/logger/wiki/hardware-overview.
     """
+    def __init__(self, response_wait_time=0.2):
+        """
+        Initialize the MCPC with SerialDevice parameters and a measurement delay.
+        """
+        super().__init__()
+        # Time in seconds to wait between sending a command and attempting to read the response.
+        # Default of .2 set via empirical testing and can be adjusted as needed.
+        self.response_wait_time = response_wait_time
+
     @staticmethod
     def _parse_values(data: str):
         """
@@ -153,7 +162,7 @@ class MCPC(SerialDevice):
         receives no data.
         """
         self.send_cmd('read')
-        time.sleep(0.1)
+        time.sleep(self.response_wait_time)
         resp = self.read_all()
         assert len(resp) > 0, "Device returned no data"
         return self._parse_values(resp)
@@ -165,7 +174,7 @@ class MCPC(SerialDevice):
         receives no data.
         """
         self.send_cmd('all')
-        time.sleep(0.2)
+        time.sleep(self.response_wait_time)
         resp = self.read_all()
         assert len(resp) > 0, "Device returned no data"
         return self._parse_values(resp)
@@ -177,10 +186,26 @@ class MCPC(SerialDevice):
         receives no data.
         """
         self.send_cmd('settings')
+        time.sleep(self.response_wait_time)
         resp = self.read_all()
         assert len(resp) > 0, "Device returned no data"
         return self._parse_values(resp)
 
+    def get_response_wait_time(self):
+        """
+        Returns the (floating-point) response wait time associated with the
+        device (i.e. the set amount of time each method waits after sending
+        a command to read the response).
+        """
+        return self.response_wait_time
+
+    def set_response_wait_time(self, response_wait_time):
+        """
+        Set the (floating-point) response wait time associated with the
+        device (i.e. the set amount of time each method waits after sending
+        a command to read the response).
+        """
+        self.response_wait_time = response_wait_time
 
 class BS1010(SerialDevice):
     """


### PR DESCRIPTION
A lot of MCPC debugging last semester came down to manually tuning the parameter associated with the wait time between when you send a command to the MCPC and when you try to read a response. This PR makes that parameter a part of the MCPC class for easy access.

There isn't a great way to test this because we don't have hardware, but I "emulated" the functions like this:
```
anusha@anusha-Latitude-5480:~/repos/logger$ python3 -i serialdevices.py 
>>> test_MCPC = MCPC(0.3)
>>> test_MCPC.get_response_wait_time()
0.3
>>> test_MCPC.set_response_wait_time(.5)
>>> test_MCPC.get_response_wait_time()
0.5
>>> time.sleep(test_MCPC.get_response_wait_time())
>>> 
```
As the main use case of this function is within the context of time.sleep(), I think this provides adequate validation of this system, though I am definitely open to other testing options if folks can come up with any.


