### PR TITLE
Clean up testing setup bash script to reflect actual ports and kill old processes.

### DIFF
--- a/test/setup_testing.sh
+++ b/test/setup_testing.sh
@@ -1,13 +1,15 @@
 # Run this script before running any of the testing and debugging programs.
 
+# Kill the background process that otherwise uses the port.
+sudo systemctl stop logger
+
 # On a new device, double check that these ports are stil correct. To do that,
 # run the command 'ls /dev/serial/by-id' with each device plugged in individually
 # and modify the MCPC and valve port names as required.
-
 # The serial port (by id) associated with the particle counter.
 export MCPC_PORT=/dev/serial/by-id/usb-FTDI_UT232R_FT0A3TYQ-if00-port0
 # The serial port (by id) associated with the 3-way valve.
-export VALVE_PORT=/dev/serial/by-id/usb-FTDI_UT232R_FT2H54CR-if00-port0
+export VALVE_PORT=usb-FTDI_UT232R_FT2H54CR-if00-port0
 # The file to log data from the CPC to.
 export SAVE_FILE=/mnt/data/data.csv
 # Time to spend on each valve, in seconds.

--- a/test/setup_testing.sh
+++ b/test/setup_testing.sh
@@ -7,10 +7,10 @@ sudo systemctl stop logger
 # run the command 'ls /dev/serial/by-id' with each device plugged in individually
 # and modify the MCPC and valve port names as required.
 # The serial port (by id) associated with the particle counter.
-export MCPC_PORT=/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller_D-if00-port0
+export MCPC_PORT="/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller_D-if00-port0"
 # The serial port (by id) associated with the 3-way valve.
-export VALVE_PORT=/dev/serial/by-id/usb-FTDI_UT232R_FT2H54CR-if00-port0
+export VALVE_PORT="/dev/serial/by-id/usb-FTDI_UT232R_FT2H54CR-if00-port0"
 # The file to log data from the CPC to.
-export SAVE_FILE=/mnt/data/data.csv
+export SAVE_FILE="/mnt/data/data.csv"
 # Time to spend on each valve, in seconds.
 export VALVE_PERIOD=300

--- a/test/setup_testing.sh
+++ b/test/setup_testing.sh
@@ -7,9 +7,9 @@ sudo systemctl stop logger
 # run the command 'ls /dev/serial/by-id' with each device plugged in individually
 # and modify the MCPC and valve port names as required.
 # The serial port (by id) associated with the particle counter.
-export MCPC_PORT=/dev/serial/by-id/usb-FTDI_UT232R_FT0A3TYQ-if00-port0
+export MCPC_PORT=/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller_D-if00-port0
 # The serial port (by id) associated with the 3-way valve.
-export VALVE_PORT=usb-FTDI_UT232R_FT2H54CR-if00-port0
+export VALVE_PORT=/dev/serial/by-id/usb-FTDI_UT232R_FT2H54CR-if00-port0
 # The file to log data from the CPC to.
 export SAVE_FILE=/mnt/data/data.csv
 # Time to spend on each valve, in seconds.


### PR DESCRIPTION
The old testing setup script was pretty limited in that the port values were placeholders (as I had no access to equipment) and there was no command to kill any existing processes that could be working over serial. This PR changes that.