### PR TITLE
Update logger env template to reflect updated port values

### DIFF
--- a/logger.env.template
+++ b/logger.env.template
@@ -1,6 +1,6 @@
-VALVE_PORT=/dev/serial/by-id/usb-FTDI_UT232R_FT0A3TYQ-if00-port0
-MCPC_PORT=/dev/serial/by-id/usb-FTDI_UT232R_FT2H54CR-if00-port0
-SAVE_FILE=/home/pi/ade-logger/data.csv
+VALVE_PORT=/dev/serial/by-id/usb-FTDI_UT232R_FT2H54CR-if00-port0
+MCPC_PORT=/dev/serial/by-id/usb-Prolific_Technology_Inc._USB-Serial_Controller_D-if00-port0
+SAVE_FILE=/mnt/data/data.csv
 
 # time to spend on each valve, in seconds
 VALVE_PERIOD=300


### PR DESCRIPTION
Added canonical (i.e. based off of two Raspis and two sets of CPCs and valves and should always be validated as per the [provisioning docs](https://github.com/airpartners/logger/wiki/provisioning) values to the logger env template instead of incorrect placeholder ones.

Also defaulted to saving the data to the /mnt partition for removal from a computer instead of off of the raspi should this become desired.