### PR TITLE
Made interactive valve test use BS1010 object instead of ThreeWayValve

### DIFF
--- a/test/interactive_valve_test.py
+++ b/test/interactive_valve_test.py
@@ -21,7 +21,7 @@ import sys
 
 # Grab the dependency from the directory above.
 sys.path.append(os.path.realpath('..'))
-from serialdevices import ThreeWayValve
+from serialdevices import BS1010
 
 def main():
     """
@@ -32,7 +32,7 @@ def main():
     parser.add_argument('--valve-baud', type=int, required=False, default=9600)
     args = parser.parse_args()
 
-    valve = ThreeWayValve()
+    valve = BS1010()
 
     # NOTE: reset=False to prevent trying to zero without connected limit switches
     valve.connect(port=args.valve_port, baudrate=args.valve_baud, reset=False)


### PR DESCRIPTION
Unclear why (probably something something interactive mode constructors etc.) but this test stopped working when using the more granular object, so switch to BS1010, which is effectively the same save for like three functions. Need to test on known working system before merging this change, but this is necessary for [Issue 36](https://github.com/airpartners/logger/issues/36). 